### PR TITLE
Include dist folder in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
     }
   },
   "files": [
-    "/dist"
+    "/dist/each.cjs.js",
+    "/dist/each.esm.js",
+    "/dist/each.umd.js"
   ],
   "homepage": "https://github.com/adaltas/node-each",
   "keywords": [


### PR DESCRIPTION
Adding `/dist` to the `.gitignore` (https://github.com/adaltas/node-each/commit/567cc2cdc5dffd18e5b67df1dde255ca67dcf67b) has caused `npm publish` to omit the dist files in the final package.

In order to include them back we could:

1. Specify each file to include in the `package.json` `files` property
2. Remove `/dist` from the `.gitignore` file
3. Adding a `.npmrc` file

This PR implements the first option.